### PR TITLE
Support for browsers that do not support Apple Script

### DIFF
--- a/BrowserRefresh.py
+++ b/BrowserRefresh.py
@@ -6,21 +6,28 @@ class BrowserRefreshCommand(sublime_plugin.TextCommand):
     def run(self, args, activate_browser=True, browserName="Google Chrome"):
         if self.view and self.view.is_dirty():
             self.view.run_command("save")
+        
+        activate = ""
+        if(activate_browser == True):
+            activate = "activate"
 
-        # ApplicationIsRunnning from, http://vgable.com/blog/2009/04/24/how-to-check-if-an-application-is-running-with-applescript/
-        browser_command = """
-        on ApplicationIsRunning(appName)
-            tell application "System Events" to set appNameIsRunning to exists (processes where name is appName)
-            return appNameIsRunning
-        end ApplicationIsRunning
+        if(browserName == "Google Chrome"):
+            command = """
+                tell application "Google Chrome"
+                    %s
+                    reload active tab of window 1
+                end tell
+            """ % (activate)
 
-        if ApplicationIsRunning("%s")
-            tell application "%s" to activate
-            tell application "System Events"
-                delay .5
-                keystroke "r" using {command down}
-            end tell
-        end if
-        """ % (browserName, browserName)
+        elif(browserName == "Safari"):
+            command = """
+                tell application "Safari"
+                    %s
+                    tell its first document
+                        set its URL to (get its URL)
+                    end tell
+                end tell
+            """ % (activate)
 
-        call(['osascript', '-e', browser_command])
+        call(['osascript', '-e', command])
+

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,7 +2,7 @@
     {
         "keys": ["command+shift+r"], "command": "browser_refresh", "args": {
             "activate_browser": true,
-            "browserName" : "Google Chrome"
+            "browserName" : "Safari"
         }
     }
 ]


### PR DESCRIPTION
...efresh the page

This update addresses a personal need to refresh browsers that don't
yet support the Apple Script dictionary for tabs/windows. The Apple
Script utilizes System Events to first activate the specified browser,
then sends the key strokes for "command+shift+r" to hard reload the
page.

Google Chrome has been kept as the default browser, but users can
specify other browsers using the `browserName` argument from the
keyboard shortcut. The default keymap file has been updated to reflect
this new option.
