### PR TITLE
Fixed default keymap path on windows

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -34,7 +34,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Default/Default (Windows).sublime-keymap",
+                                    "file": "${packages}/Browser Refresh/Default (Windows).sublime-keymap",
                                     "platform": "Windows"
                                 },
                                 "caption": "Key Bindings – Default"


### PR DESCRIPTION
Default keymap settings does not open properly on windows.
I found that the keymap path is incorrect, and modified it.
