### PR TITLE
Support activate_browser in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ To edit settings go to `Preferences > Package Settings > Browser Refresh`
 
 **auto_save** - If set to `true` you current file in Sublime Text will be save before refreshing the browser window.
 
-**delay** - Adds a delay (in seconds) before triggering the refresh. Seems to be useful if you are using a CSS or JavaScript pre-processor. The default is 0.0 seconds. 
+**delay** - Adds a delay (in seconds) before triggering the refresh. Seems to be useful if you are using a CSS or JavaScript pre-processor. The default is 0.0 seconds.
 
-**activate_browser** - If set to `true` when you press the keys it will bring the browser to the foreground. **Note:** On Windows this setting is always `true`.
+**activate_browser** - If set to `true` when you press the keys it will bring the browser to the foreground.
 
-**browser_name** - Specify which browser to use. The default is `Google Chrome` but you can change it to `Google Chrome Canary`, `Safari`,`Firefox`, `Opera`, `IE`, `Iron` 
+**browser_name** - Specify which browser to use. The default is `Google Chrome` but you can change it to `Google Chrome Canary`, `Safari`,`Firefox`, `Opera`, `IE`, `Iron`
 or `all` which will try to refresh any of the above present in your system. **Note**: on Windows use `Google Chrome` if you want to use Canary, because at the moment it's very hard to
 distinguish between them as both report themselves as Chrome. This also means that if you have both Chrome and Canary running, it will refresh the active tab on both browsers.
 

--- a/win/__init__.py
+++ b/win/__init__.py
@@ -72,10 +72,10 @@ class WinBrowserRefresh:
         # We need to store all window handles that have been sent keys in order
         # to avoid reactivating windows and doing unnecesary refreshes. This is a
         # side effect of having to call Application.connect_ on each regex match.
-        # We need to loop through each open window collection to support edge 
+        # We need to loop through each open window collection to support edge
         # cases like Google Canary where the Window title is identical to Chrome.
         processed_handles = []
-        
+
         for win in all_matches:
             app = Application()
             app.connect_(handle = win)
@@ -86,6 +86,8 @@ class WinBrowserRefresh:
                     continue
 
                 openwin.TypeKeys('{F5}')
-                processed_handles.append(openwin.handle) 
+                if False == self.activate:
+                    openwin.TypeKeys('%{TAB}')
+                processed_handles.append(openwin.handle)
                 time.sleep(1)
 


### PR DESCRIPTION
Emulate activate_browser support in Windows by using the ALT+TAB shortcut to jump back to the previous window.
