### PR TITLE
Print Command - Changed to valid syntax for Python 3.3

### DIFF
--- a/mac/__init__.py
+++ b/mac/__init__.py
@@ -20,7 +20,7 @@ class MacBrowserRefresh:
             """
 
     def _chrome(self, app_name, browser_name):
-        print 'print command did run'
+        print ('print command did run')
         command = self._chrome_applescript.format(
             name=app_name, activate=self.activate)
 
@@ -85,5 +85,5 @@ class MacBrowserRefresh:
             self._call_applescript(command)
 
     def _call_applescript(self, command):
-        print '_call_applescript'
+        print ('_call_applescript')
         call(['osascript', '-e', command])


### PR DESCRIPTION
Quick fix so I can still keep using BrowserRefresh in ST3 on Mac.
