### PR TITLE
Fixing focus issue in Chrome on Linux

### DIFF
--- a/linux/__init__.py
+++ b/linux/__init__.py
@@ -37,7 +37,7 @@ class LinuxBrowserRefresh:
     def SendKeysToAllWindows(self, cls, key):
         "Sends the keystroke to all windows whose title matches the regex"
 
-        cmd = ['xdotool', 'search', '--sync', '--onlyvisible', '--class', cls, 'key', key]
+        cmd = ['xdotool', 'search', '--sync', '--onlyvisible', '--class', cls, 'windowfocus', 'key', key]
 
         if self.activate_browser:
             cmd += ['windowactivate']


### PR DESCRIPTION
Due to a new update in Chrome, xdotool isn't able to make chrome obey orders whenever the Chrome window is not in focus.

By adding windowfocus to the script (linux/__init_.py) at line 40 this issue gets resolved.

This problem is described in: https://github.com/gcollazo/BrowserRefresh-Sublime/issues/61#issuecomment-62256891