### PR TITLE
Remove prompt to manually add keyboard shortcut

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -17,22 +17,6 @@ ______      __               _
                                        
 Thanks for installing Browser Refresh!
 
-* * Important * *
-To complete the installation make sure you add the necessary key bindings.
-Go to "Preferences" > "Package Settings" > "Browser Refresh" > "Key Bindings - User"
-in the menu and add the following:
- 
-[
-  {
-    "keys": ["super+shift+r"], "command": "browser_refresh", "args": {
-      "auto_save": true,
-      "delay": 0.0,
-      "activate": true,
-      "browsers" : ["chrome"]
-    }
-  }
-]
-
 For complete documentation please visit:
 https://github.com/gcollazo/BrowserRefresh-Sublime
 


### PR DESCRIPTION
The plugin comes with default keybindings set already and asks the user to add the same shortcut in the user settings.